### PR TITLE
Feature : adding blocked days data retrieval from ics calendar

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          poetry install --without dev
+          poetry install --without dev --with streamlit_app
         working-directory: ${{ github.workspace }}
 
       - name: Generate Google API Token
@@ -111,3 +111,13 @@ jobs:
           NOTION_API: ${{ secrets.NOTION_API }}
           DATABASE_ID: ${{ secrets.DATABASE_ID }}
           PROJECT_ROOT: ${{ github.workspace }}
+
+      - name: Retrieve blocked days from ics Calendar
+        shell: bash
+        run: |
+          poetry run python services/dataviz/src/get_blocked_days.py
+        working-directory: ${{ github.workspace }}
+        env:
+          NOTION_API: ${{ secrets.NOTION_API }}
+          DATE_DATABASE_ID: ${{ secrets.DATE_DATABASE_ID }}
+          CALENDAR_URL: ${{ secrets.CALENDAR_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 **token.json
 **reservations.csv
+poetry.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,12 @@ flake8 = "^7.1.1"
 black = "^22.3.0"
 isort = "^6.0.0"
 
+[tool.poetry.group.streamlit_app.dependencies]
+streamlit = "^1.21.0"
+pandas = "2.1.3"
+plotly = "^5.0.0"
+ics = "^0.7"
+
 [tool.isort]
 profile = "black"
 

--- a/services/dataviz/README.md
+++ b/services/dataviz/README.md
@@ -1,0 +1,21 @@
+# Notion Data Visualization App
+
+This is a Streamlit application that fetches data from a Notion client, stores it locally as a CSV file, and serves a data visualization web app.
+
+## Setup Instructions
+
+1. Clone the repository.
+2. Navigate to the `dataviz` directory.
+3. Install the required packages:
+   ```
+   poetry install --without dev --with streamlit_app
+   ```
+4. Set up your Notion API key and database ID in your environment variables.
+5. Run the Streamlit app:
+   ```
+   streamlit run src/app.py
+   ```
+
+## Usage
+
+The app will fetch data from Notion every 60 seconds and display it in a table format. You can modify the fetching interval by changing the `time.sleep(60)` value in `app.py`.

--- a/services/dataviz/TODO.md
+++ b/services/dataviz/TODO.md
@@ -1,0 +1,116 @@
+- Retrieve_Blocked_days scheduled ! (in Run workflow another )
+
+- Add all fetch methods into one single file 
+- Add a method to initialize all Datasets (Parent page & Notion API key & Share integration) and save all results in a file .DATABASES_ID and then github secrets 
+- Trouver un moyen de mapper tout les pays à un code Pays pour ploter sur une carte
+
+## Réaliser la liste des graphs suivants :
+
+- [ ]  Ventilation des prixs
+    - [ ]  Double histogramme gost vs host payout
+    - [ ]  Axe abscisse : Nombre de jour de réservation 
+
+- [ ]  Graphique Mensuel prix
+    - [ ]  Y : Prix moyen par nuit
+    - [ ]  X : Mois (dépense inputé sur le moi de arrival Date)
+- [ ]  Graphique Mensuel
+    - [ ]  Y : Box plot nombre de jours d’une réservation
+    - [ ]  X : Mois
+- [ ]  Map plot (color scale) for all the countries 
+- [ ]  Occupency (Mensuel)
+    - [ ]  Nombre de jours bouqué
+    - [ ]  Nombre de jour réservé
+    - [ ]  Nombre de jour innocupés
+
+Faire un graph en absice nombre d’étoiles, et sur le box plot prix par nuit !
+
+
+
+--- 
+
+## Map plot solutions
+
+```python
+import pandas as pd
+import plotly.express as px
+
+# Example DataFrame with country names
+df = pd.DataFrame({
+    "country": ["Philippines", "New Zealand", "United Kingdom", "India", "Morocco"],
+    "value": [10, 20, 30, 40, 50]
+})
+
+fig = px.choropleth(
+    df,
+    locations="country",
+    locationmode="country names",  # Tells Plotly to interpret the locations as country names
+    color="value",
+    title="Choropleth by Country Name"
+)
+fig.show()
+```
+
+```python
+# Example DataFrame with ISO-3 country codes
+df = pd.DataFrame({
+    "iso_code": ["PHL", "NZL", "GBR", "IND", "MAR"],
+    "value": [10, 20, 30, 40, 50]
+})
+
+fig = px.choropleth(
+    df,
+    locations="iso_code",
+    locationmode="ISO-3",  # Tells Plotly to interpret the locations as ISO-3 country codes
+    color="value",
+    title="Choropleth by ISO Code"
+)
+fig.show()
+```
+
+```python
+import pandas as pd
+import plotly.express as px
+import pycountry
+
+# Function to convert input (either name or code) to ISO-3 code
+def to_iso3(country_input):
+    try:
+        # Try to interpret as a country name first
+        return pycountry.countries.lookup(country_input).alpha_3
+    except LookupError:
+        # If lookup fails, assume it might already be an ISO code and check length
+        if len(country_input) in [2, 3]:
+            # Optionally, validate it or convert 2-letter codes to 3-letter ones
+            try:
+                country = pycountry.countries.get(alpha_2=country_input.upper())
+                return country.alpha_3 if country else country_input.upper()
+            except Exception:
+                return country_input.upper()
+        # Otherwise, return the input unchanged or handle as needed
+        return country_input.upper()
+
+# Example DataFrame with mixed country identifiers
+data = {
+    "location": [
+        "Philippines", "NZL", "United Kingdom", "United Kingdom", "India", 
+        "IND", "Morocco", "FR", "FRA", "France", "OK", "Canada", "CAN", "CA", 
+        "United Arab Emirates", "US", "USA"
+    ],
+    "value": [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170]
+}
+df = pd.DataFrame(data)
+
+# Standardize the 'location' column to ISO-3 codes
+df['iso_code'] = df['location'].apply(to_iso3)
+
+# Create a choropleth map using Plotly Express with ISO-3 codes
+fig = px.choropleth(
+    df,
+    locations="iso_code",
+    locationmode="ISO-3",  # Use ISO-3 codes for mapping
+    color="value",
+    title="Choropleth Map with Standardized Country Codes"
+)
+fig.show()
+
+```

--- a/services/dataviz/script/setup_notion_db.sh
+++ b/services/dataviz/script/setup_notion_db.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./setup_notion_db.sh [parent_page_id]
+# If no parent_page_id is supplied, the default is used.
+PARENT_PAGE_ID="${1:-19519fda9f9d80bfb700fa81c0417df3}"
+
+# Ensure NOTION_API env variable is set
+if [ -z "${NOTION_API:-}" ]; then
+    echo "Error: NOTION_API environment variable must be set" >&2
+    exit 1
+fi
+
+# Create a Notion database with a title property and two date properties: start_date and end_date.
+create_db_response=$(curl -s -X POST "https://api.notion.com/v1/databases" \
+    -H "Authorization: Bearer ${NOTION_API}" \
+    -H "Content-Type: application/json" \
+    -H "Notion-Version: 2022-06-28" \
+    -d '{
+        "parent": { "page_id": "'"${PARENT_PAGE_ID}"'" },
+        "title": [
+          {
+            "type": "text",
+            "text": {
+              "content": "Blocked Dates Database"
+            }
+          }
+        ],
+        "properties": {
+            "Name": { "title": {} },
+            "Start Date": { "date": {} },
+            "End Date": { "date": {} },
+            "Insert Date": { "date": {} }
+        }
+    }')
+
+# Extract the database id from the response.
+database_id=$(echo "$create_db_response" | jq -r '.id')
+
+if [ "$database_id" = "null" ]; then
+    echo "Failed to create database:" >&2
+    echo "$create_db_response" >&2
+    exit 1
+fi
+
+echo "Created database with ID: $database_id"
+script_dir=$(dirname "$0")
+echo "$database_id" > "$script_dir/database_id.txt"

--- a/services/dataviz/src/app.py
+++ b/services/dataviz/src/app.py
@@ -1,0 +1,146 @@
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from services.notion_client.notion_api_client import NotionClient
+
+
+# -----------------------------
+# DATA FETCHING & CACHING
+# -----------------------------
+@st.cache_data(ttl=3600 * 24)
+def fetch_data_from_notion():
+    """Fetch data from Notion via the client and return a cleaned DataFrame."""
+    notion_client = NotionClient()
+    pages = notion_client.get_all_pages()
+    data = [notion_client.parse_page(page) for page in pages]
+    df = pd.DataFrame(data)
+
+    # Convert date columns to datetime
+    for col in ["Arrival Date", "Departure Date", "Mail Date", "Insert Date"]:
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], errors="coerce")
+
+    # Ensure numeric columns are properly converted.
+    # Adjust the list below if needed.
+    for col in [
+        "Host Service Fee",
+        "Guest Service Fee",
+        "Total Nights Cost",
+        "Guest Payout",
+        "Host Payout",
+        "Cleaning Fee",
+        "Tourist Tax",
+        "Price by night",
+        "Number of Nights",
+    ]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    return df
+
+
+# Button to refresh data manually (which clears the cache)
+if st.button("Refresh Data"):
+    st.cache_data.clear()  # clear the cached data
+    st.rerun()
+
+# Fetch (or load cached) data
+df = fetch_data_from_notion()
+
+# -----------------------------
+# GLOBAL FILTERS
+# -----------------------------
+st.title("Notion Data Visualization")
+st.write(
+    "Data fetched from Notion. Use the filters and charts below to explore the data."
+)
+
+# Create a global year filter based on the "Arrival Date"
+if "Arrival Date" in df.columns:
+    df["year"] = df["Arrival Date"].dt.year
+    available_years = sorted(df["year"].dropna().unique())
+    if available_years:
+        selected_year = st.selectbox("Select Year", options=available_years)
+        df_filtered = df[df["year"] == selected_year].copy()
+    else:
+        st.error("No valid 'Arrival Date' data found.")
+        df_filtered = df.copy()
+else:
+    st.error("'Arrival Date' column is missing from the data.")
+    df_filtered = df.copy()
+
+# -----------------------------
+# GRAPH 1: Average Payouts vs. Number of Nights
+# -----------------------------
+st.subheader("Average Payouts vs. Number of Nights")
+
+# Make sure the necessary columns are available and numeric.
+for col in ["Number of Nights", "Host Payout", "Guest Payout"]:
+    if col not in df_filtered.columns:
+        st.error(f"Column '{col}' is missing from the data.")
+        st.stop()
+
+# Group by Number of Nights and compute average payouts.
+grouped = (
+    df_filtered.groupby("Number of Nights")
+    .agg({"Host Payout": "mean", "Guest Payout": "mean"})
+    .reset_index()
+)
+
+# Reshape for a grouped bar chart.
+grouped_melted = grouped.melt(
+    id_vars="Number of Nights",
+    value_vars=["Host Payout", "Guest Payout"],
+    var_name="Payout Type",
+    value_name="Average Payout",
+)
+
+fig1 = px.bar(
+    grouped_melted,
+    x="Number of Nights",
+    y="Average Payout",
+    color="Payout Type",
+    barmode="group",
+    title="Average Payout vs. Number of Nights",
+)
+st.plotly_chart(fig1, use_container_width=True)
+
+# -----------------------------
+# GRAPH 2: Box Plot of Nightly Price Distribution by Month
+# -----------------------------
+if "Arrival Date" in df_filtered.columns and "Price by night" in df_filtered.columns:
+    df_filtered.loc[:, "month_year"] = (
+        df_filtered["Arrival Date"].dt.to_period("M").astype(str)
+    )
+    # Create a box plot showing the distribution of nightly prices for each month
+    fig2 = px.box(
+        df_filtered,
+        x="month_year",
+        y="Price by night",
+        title="Box Plot: Nightly Price Distribution by Month (Based on Arrival Date)",
+        labels={"month_year": "Month-Year", "Price by night": "Nightly Price"},
+    )
+    st.plotly_chart(fig2, use_container_width=False)
+else:
+    st.error("Required columns for monthly price analysis are missing.")
+
+# -----------------------------
+# GRAPH 3: Box Plot of Days of Stay by Month
+# -----------------------------
+st.subheader("Distribution of Number of Nights by Month")
+
+if "Arrival Date" in df_filtered.columns and "Number of Nights" in df_filtered.columns:
+    # Extract month name
+    df_filtered.loc[:, "month"] = df_filtered["Arrival Date"].dt.strftime("%B")
+
+    fig3 = px.box(
+        df_filtered,
+        x="month",
+        y="Number of Nights",
+        title="Box Plot: Number of Nights by Month (Arrival Date)",
+        labels={"month": "Month", "Number of Nights": "Days of Stay"},
+    )
+    st.plotly_chart(fig3, use_container_width=True)
+else:
+    st.error("Required columns for box plot analysis are missing.")

--- a/services/dataviz/src/get_blocked_days.py
+++ b/services/dataviz/src/get_blocked_days.py
@@ -118,6 +118,6 @@ if __name__ == "__main__":
     try:
         calendar_url = os.environ.get("CALENDAR_URL")
         push_blocked_days_to_notion(calendar_url)
-        print(f"Successfully pushed blocked days from calendar to Notion")
+        print("Successfully pushed blocked days from calendar to Notion")
     except Exception as e:
         print(f"Failed to push blocked days to Notion: {e}")

--- a/services/dataviz/src/get_blocked_days.py
+++ b/services/dataviz/src/get_blocked_days.py
@@ -1,0 +1,123 @@
+import datetime
+import os
+
+import pandas as pd
+import requests
+from ics import Calendar
+from notion_client import Client
+
+BLOCKED_DATE_DB_ID = os.environ.get("DATE_DATABASE_ID")
+TOKEN = os.environ.get("NOTION_API")
+
+
+def fetch_blocked_days_from_airbnb_ical(calendar_url: str):
+    r = requests.get(calendar_url)
+    r.raise_for_status()
+
+    calendar = Calendar(r.text)
+
+    blocked_events = [
+        event for event in calendar.events if "Airbnb (Not available)" in event.name
+    ]
+
+    data = []
+    for evt in blocked_events:
+        data.append(
+            {
+                "start_date": evt.begin.date(),
+                "end_date": evt.end.date(),
+                "Name": evt.name,
+            }
+        )
+    df_blocked = pd.DataFrame(data)
+    return df_blocked
+
+
+def push_blocked_days_to_notion(calendar_url: str):
+    """
+    Pushes blocked day entries from an Airbnb iCal URL to a Notion database.
+
+    This function fetches blocked dates from an Airbnb calendar by retrieving data
+    from the provided calendar URL and then checks against existing entries in a
+    Notion database. For each blocked day record that meets specific criteria (e.g.
+    duration of block does not exceed 7 days), it creates a new page in the Notion
+    database with the provided details.
+
+    Parameters:
+        calendar_url (str):
+            The URL of the Airbnb calendar in iCal format from which to fetch blocked dates.
+
+    Side Effects:
+        - Queries and creates pages in a Notion database. Existing pages already present
+          with the same start and end dates will not be duplicated.
+        - Skips inserting records for blocked periods longer than 7 days.
+        - The function uses the current timestamp as the insertion date for newly created pages.
+
+    Raises:
+        Any exceptions raised by the underlying Notion client upon failure to execute database
+        queries or page creation may propagate up to the caller.
+    """
+    notion_client = Client(auth=TOKEN)
+    df_blocked = fetch_blocked_days_from_airbnb_ical(calendar_url)
+    existing_pages = notion_client.databases.query(database_id=BLOCKED_DATE_DB_ID).get(
+        "results", []
+    )
+
+    for _, row in df_blocked.iterrows():
+        start = row["start_date"]
+        end = row["end_date"]
+
+        if (end - start).days > 7:
+            continue
+
+        insert_date = datetime.datetime.now().isoformat()
+
+        if not any(
+            str(start) in str(page) and str(end) in str(page) for page in existing_pages
+        ):
+            notion_client.pages.create(
+                parent={"database_id": BLOCKED_DATE_DB_ID},
+                properties={
+                    "Name": {"title": [{"text": {"content": row["Name"]}}]},
+                    "Start Date": {"date": {"start": str(start)}},
+                    "End Date": {"date": {"start": str(end)}},
+                    "Insert Date": {"date": {"start": insert_date}},
+                },
+            )
+
+
+def fetch_blocked_days_from_notion() -> pd.DataFrame:
+    notion_client = Client(auth=TOKEN)
+    pages = notion_client.databases.query(database_id=BLOCKED_DATE_DB_ID).get(
+        "results", []
+    )
+    data = []
+    for page in pages:
+        props = page.get("properties", {})
+        start_date = props.get("Start Date", {}).get("date", {}).get("start", None)
+        end_date = props.get("End Date", {}).get("date", {}).get("start", None)
+        name = (
+            props.get("Name", {})
+            .get("title", [{}])[0]
+            .get("text", {})
+            .get("content", "")
+        )
+        insert_date = props.get("Insert Date", {}).get("date", {}).get("start", None)
+        data.append(
+            {
+                "start_date": start_date,
+                "end_date": end_date,
+                "Name": name,
+                "Insert Date": insert_date,
+            }
+        )
+    return pd.DataFrame(data)
+
+
+if __name__ == "__main__":
+    try:
+        calendar_url = os.environ.get("CALENDAR_URL")
+        push_blocked_days_to_notion(calendar_url)
+        print(f"Successfully pushed blocked days from calendar to Notion")
+    except Exception as e:
+        print(f"Failed to push blocked days to Notion: {e}")

--- a/tests/unit/test_get_blocked_days.py
+++ b/tests/unit/test_get_blocked_days.py
@@ -1,0 +1,70 @@
+import datetime
+
+import pandas as pd
+import requests
+
+# Import the module to test
+from services.dataviz.src import get_blocked_days
+
+
+# Dummy classes to simulate calendar events and datetime objects
+class DummyDt:
+    def __init__(self, date_val):
+        self._date = date_val
+
+    def date(self):
+        return self._date
+
+
+class DummyEvent:
+    def __init__(self, name, begin, end):
+        self.name = name
+        self.begin = begin
+        self.end = end
+
+
+class DummyCalendar:
+    def __init__(self, text):
+        # Create one event that matches and one that doesn't
+        self.events = [
+            DummyEvent(
+                "Airbnb (Not available)",
+                DummyDt(datetime.date(2023, 10, 10)),
+                DummyDt(datetime.date(2023, 10, 11)),
+            ),
+            DummyEvent(
+                "Other event",
+                DummyDt(datetime.date(2023, 10, 12)),
+                DummyDt(datetime.date(2023, 10, 13)),
+            ),
+        ]
+
+
+class DummyResponse:
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def dummy_get(url):
+    return DummyResponse("dummy calendar text")
+
+
+def test_fetch_blocked_days(monkeypatch):
+    # Patch requests.get
+    monkeypatch.setattr(requests, "get", dummy_get)
+
+    # Patch Calendar in the module with our DummyCalendar
+    monkeypatch.setattr(get_blocked_days, "Calendar", DummyCalendar)
+
+    df = get_blocked_days.fetch_blocked_days_from_airbnb_ical("http://dummy-url")
+
+    # Assert only one event (matching the "Airbnb (Not available)" string) is returned
+    assert isinstance(df, pd.DataFrame)
+    assert df.shape[0] == 1
+    row = df.iloc[0]
+    assert row["start_date"] == datetime.date(2023, 10, 10)
+    assert row["end_date"] == datetime.date(2023, 10, 11)
+    assert row["Name"] == "Airbnb (Not available)"


### PR DESCRIPTION
This pull request introduces a new feature to fetch blocked days from an Airbnb iCal URL and push them to a Notion database. It includes changes to the workflow configuration, the addition of a new script, and corresponding unit tests.

### Workflow Configuration:

* [`.github/workflows/run.yml`](diffhunk://#diff-a3ddd7238fc6e36daeb0ef76e93fe15cc87824bd3299888075210c5ca6a474d3L90-R90): Updated the dependency installation command to include the `streamlit_app` and added a new job to retrieve blocked days from the iCal calendar and push them to Notion. [[1]](diffhunk://#diff-a3ddd7238fc6e36daeb0ef76e93fe15cc87824bd3299888075210c5ca6a474d3L90-R90) [[2]](diffhunk://#diff-a3ddd7238fc6e36daeb0ef76e93fe15cc87824bd3299888075210c5ca6a474d3R114-R123)

### New Script:

* [`services/dataviz/src/get_blocked_days.py`](diffhunk://#diff-83d8c18ec021f089538fad23466845c703830e9ab32d71a1fd358ef2d3bcbc8aR1-R123): Added a new script to fetch blocked days from an Airbnb iCal URL and push them to a Notion database. This script includes functions to fetch blocked days, push them to Notion, and retrieve blocked days from Notion.

### Unit Tests:

* [`tests/unit/test_get_blocked_days.py`](diffhunk://#diff-21cf15e7e9321281ba643b9700bd643cbcc4fa2867332882e42498a39d3be8a7R1-R70): Added unit tests for the new script, including dummy classes and functions to simulate calendar events and responses.